### PR TITLE
Add WebSocket BookTickerEvent

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
@@ -1,10 +1,6 @@
 package com.binance.api.client;
 
-import com.binance.api.client.domain.event.AggTradeEvent;
-import com.binance.api.client.domain.event.AllMarketTickersEvent;
-import com.binance.api.client.domain.event.CandlestickEvent;
-import com.binance.api.client.domain.event.DepthEvent;
-import com.binance.api.client.domain.event.UserDataUpdateEvent;
+import com.binance.api.client.domain.event.*;
 import com.binance.api.client.domain.market.CandlestickInterval;
 
 import java.io.Closeable;
@@ -59,6 +55,15 @@ public interface BinanceApiWebSocketClient extends Closeable {
      * @return a {@link Closeable} that allows the underlying web socket to be closed.
      */
     Closeable onAllMarketTickersEvent(BinanceApiCallback<List<AllMarketTickersEvent>> callback);
+
+    /**
+     * Open a new web socket to receive {@link BookTickerEvent bookTickerEvents} on a callback.
+     *
+     * @param symbols   market (one or coma-separated) symbol(s) to subscribe to
+     * @param callback  the callback to call on new events
+     * @return a {@link Closeable} that allows the underlying web socket to be closed.
+     */
+    Closeable onBookTickerEvent(String symbols, BinanceApiCallback<BookTickerEvent> callback);
 
     /**
      * @deprecated This method is no longer functional. Please use the returned {@link Closeable} from any of the other methods to close the web socket.

--- a/src/main/java/com/binance/api/client/domain/event/BookTickerEvent.java
+++ b/src/main/java/com/binance/api/client/domain/event/BookTickerEvent.java
@@ -1,0 +1,113 @@
+package com.binance.api.client.domain.event;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.binance.api.client.constant.BinanceApiConstants;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * BookTickerEvent event for a symbol. Pushes any update to the best bid or
+ * ask's price or quantity in real-time for a specified symbol.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BookTickerEvent {
+
+    @JsonProperty("u")
+    private long updateId;
+
+    @JsonProperty("s")
+    private String symbol;
+
+    @JsonProperty("b")
+    private String bidPrice;
+
+    @JsonProperty("B")
+    private String bidQuantity;
+
+    @JsonProperty("a")
+    private String askPrice;
+
+    @JsonProperty("A")
+    private String askQuantity;
+
+    public BookTickerEvent() {
+        super();
+    }
+
+    public BookTickerEvent(long updateId, String symbol, String bidPrice, String bidQuantity, String askPrice,
+                           String askQuantity) {
+        super();
+        this.updateId = updateId;
+        this.symbol = symbol;
+        this.bidPrice = bidPrice;
+        this.bidQuantity = bidQuantity;
+        this.askPrice = askPrice;
+        this.askQuantity = askQuantity;
+    }
+
+    public BookTickerEvent(String symbol, String bidPrice, String bidQuantity, String askPrice, String askQuantity) {
+        super();
+        this.symbol = symbol;
+        this.bidPrice = bidPrice;
+        this.bidQuantity = bidQuantity;
+        this.askPrice = askPrice;
+        this.askQuantity = askQuantity;
+    }
+
+    public long getUpdateId() {
+        return updateId;
+    }
+
+    public void setUpdateId(long updateId) {
+        this.updateId = updateId;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public String getBidPrice() {
+        return bidPrice;
+    }
+
+    public void setBidPrice(String bidPrice) {
+        this.bidPrice = bidPrice;
+    }
+
+    public String getBidQuantity() {
+        return bidQuantity;
+    }
+
+    public void setBidQuantity(String bidQuantity) {
+        this.bidQuantity = bidQuantity;
+    }
+
+    public String getAskPrice() {
+        return askPrice;
+    }
+
+    public void setAskPrice(String askPrice) {
+        this.askPrice = askPrice;
+    }
+
+    public String getAskQuantity() {
+        return askQuantity;
+    }
+
+    public void setAskQuantity(String askQuantity) {
+        this.askQuantity = askQuantity;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, BinanceApiConstants.TO_STRING_BUILDER_STYLE).append("eventType", "BookTicker")
+                .append("updateId", updateId).append("symbol", symbol).append("bidPrice", bidPrice)
+                .append("bidQuantity", bidQuantity).append("askPrice", askPrice).append("askQuantity", askQuantity)
+                .toString();
+    }
+}

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -4,11 +4,7 @@ import com.binance.api.client.BinanceApiCallback;
 import com.binance.api.client.BinanceApiWebSocketClient;
 import com.binance.api.client.config.BinanceApiConfig;
 import com.binance.api.client.constant.BinanceApiConstants;
-import com.binance.api.client.domain.event.AggTradeEvent;
-import com.binance.api.client.domain.event.AllMarketTickersEvent;
-import com.binance.api.client.domain.event.CandlestickEvent;
-import com.binance.api.client.domain.event.DepthEvent;
-import com.binance.api.client.domain.event.UserDataUpdateEvent;
+import com.binance.api.client.domain.event.*;
 import com.binance.api.client.domain.market.CandlestickInterval;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -65,6 +61,15 @@ public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient,
     public Closeable onAllMarketTickersEvent(BinanceApiCallback<List<AllMarketTickersEvent>> callback) {
         final String channel = "!ticker@arr";
         return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, new TypeReference<List<AllMarketTickersEvent>>() {}));
+    }
+
+    @Override
+    public Closeable onBookTickerEvent(String symbols, BinanceApiCallback<BookTickerEvent> callback) {
+        final String channel = Arrays.stream(symbols.split(","))
+                .map(String::trim)
+                .map(s -> String.format("%s@bookTicker", s))
+                .collect(Collectors.joining("/"));
+        return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, BookTickerEvent.class));
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
- Add the _onBookTickerEvent_ WebSocket to BinanceApiWebSocketClient, for stream _'best price/qty on the order book for a symbol or symbols'._ consider the endpoint `[GET /api/v3/ticker/bookTicker](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md)`
- Remove some un-used imports.

#### Where should the reviewer start?
- src/main/java/com/binance/api/client/domain/event/BookTickerEvent.java
- src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
- src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java

#### How should this be manually tested?
1. Implementing a new BinanceApiWebSocketClient.onBookTickerEvent

#### Any background context you want to provide?
Implements the best price/qty on the order book for a symbol or symbols' websoccket.

![image](https://user-images.githubusercontent.com/26239543/80873019-5f8a8100-8c7b-11ea-90f2-eb4fb07c9018.png)
